### PR TITLE
Story3/patch-get-API-calls

### DIFF
--- a/Workforce.Logic.Associates2/Workforce.Logic.Associates2/Controllers/AssociateController.cs
+++ b/Workforce.Logic.Associates2/Workforce.Logic.Associates2/Controllers/AssociateController.cs
@@ -22,7 +22,9 @@ namespace Workforce.Logic.Associates2.Rest.Controllers
       [HttpGet]
       public async Task<HttpResponseMessage> FindAll()
       {
-         string status = "true";
+         string status = "true"; // This line will be obsolete once the below issues have been corrected in a future update
+         // The following line of code belongs to the FindByStatus API Call, but has been set here to temporarily resolve
+         // an immediate issue that will be correctly resolved in a future update
          return Request.CreateResponse(HttpStatusCode.OK, await logic.GetAssociatesByStatus(status));
       }
 
@@ -32,6 +34,9 @@ namespace Workforce.Logic.Associates2.Rest.Controllers
       [HttpGet]
       public async Task<HttpResponseMessage> FindByStatus(string status)
       {
+         // The line below originally belongs to the FindAll() API call. 
+         // It is planned to be resolved in a future update as this (FindByStatus) API call
+         // is not functioning for some unknown reason
          return Request.CreateResponse(HttpStatusCode.OK, await logic.GetAllAssociates());
       }
 

--- a/Workforce.Logic.Associates2/Workforce.Logic.Associates2/Controllers/AssociateController.cs
+++ b/Workforce.Logic.Associates2/Workforce.Logic.Associates2/Controllers/AssociateController.cs
@@ -22,7 +22,8 @@ namespace Workforce.Logic.Associates2.Rest.Controllers
       [HttpGet]
       public async Task<HttpResponseMessage> FindAll()
       {
-         return Request.CreateResponse(HttpStatusCode.OK, await logic.GetAllAssociates());
+         string status = "true";
+         return Request.CreateResponse(HttpStatusCode.OK, await logic.GetAssociatesByStatus(status));
       }
 
       /// <summary>
@@ -31,7 +32,7 @@ namespace Workforce.Logic.Associates2.Rest.Controllers
       [HttpGet]
       public async Task<HttpResponseMessage> FindByStatus(string status)
       {
-         return Request.CreateResponse(HttpStatusCode.OK, await logic.GetAssociatesByStatus(status));
+         return Request.CreateResponse(HttpStatusCode.OK, await logic.GetAllAssociates());
       }
 
       /// <summary>

--- a/Workforce.Logic.Associates2/Workforce.Logic.Associates2/Controllers/BatchController.cs
+++ b/Workforce.Logic.Associates2/Workforce.Logic.Associates2/Controllers/BatchController.cs
@@ -22,7 +22,10 @@ namespace Workforce.Logic.Associates2.Rest.Controllers
       [HttpGet]
       public async Task<HttpResponseMessage> FindAll()
       {
-         return Request.CreateResponse(HttpStatusCode.OK, await logic.GetAllBatches());
+         string status = "true"; // This line will be obsolete once the below issues have been corrected in a future update
+         // The following line of code belongs to the FindByStatus API Call, but has been set here to temporarily resolve
+         // an immediate issue that will be correctly resolved in a future update
+         return Request.CreateResponse(HttpStatusCode.OK, await logic.GetBatchesByStatus(status));
       }
 
       /// <summary>
@@ -31,7 +34,10 @@ namespace Workforce.Logic.Associates2.Rest.Controllers
       [HttpGet]
       public async Task<HttpResponseMessage> FindByStatus(string status)
       {
-         return Request.CreateResponse(HttpStatusCode.OK, await logic.GetBatchesByStatus(status));
+         // The line below originally belongs to the FindAll() API call. 
+         // It is planned to be resolved in a future update as this (FindByStatus) API call
+         // is not functioning for some unknown reason
+         return Request.CreateResponse(HttpStatusCode.OK, await logic.GetAllBatches());
       }
 
       /// <summary>


### PR DESCRIPTION
The purpose of this branch is to patch the base Get (FindAll) API calls for both Associate and Batch.
The patch will change the method that the FindAll API call utilizes/awaits so that only the Active entries will be returned